### PR TITLE
州名・公立私立の区分を出力に追加/出力サンプルを追加

### DIFF
--- a/export_sample.csv
+++ b/export_sample.csv
@@ -1,0 +1,40 @@
+No,Name,Bundesland,Schultyp,E-Mail
+1,Ameisenbergschule Grund- und Hauptschule,Baden-Württemberg,Öffentlich,poststelle.ameisenbergschule@stuttgart.de
+2,Falkert-Schule Grund- und Hauptschule mit Werkrealschule,Baden-Württemberg,Öffentlich,falkertschule@stuttgart.de
+3,Vogelsangschule Grundschule,Baden-Württemberg,Öffentlich,
+4,Grund- und Werkrealschule Gablenberg,Baden-Württemberg,Öffentlich,gwrs.gablenberg@stuttgart.de
+5,Grundschule Gaisburg,Baden-Württemberg,Öffentlich,gsgaisburg@stuttgart.de
+6,Heusteigschule Grund- und Werkrealschule,Baden-Württemberg,Öffentlich, heusteigschule@stuttgart.de
+7,Grundschule im Sonnigen Winkel,Baden-Württemberg,Öffentlich,schule.im.sonnigen.winkel@stuttgart. de
+8,Grundschule im Sonnigen Winkel Außenstelle Leibnizstraße,Baden-Württemberg,Öffentlich,
+9,Jakobschule Grundschule,Baden-Württemberg,Öffentlich,jakobschule@stuttgart.de
+10,Lerchenrainschule Grundschule,Baden-Württemberg,Öffentlich,lerchenrainschule@stuttgart.de
+11,Wilhelm-Hauff-Schule Grundschule,Baden-Württemberg,Öffentlich,wilhelm-hauff-grundschule@web.de
+12,Mühlbachhof-Grundschule,Baden-Württemberg,Öffentlich,Muehlbachhofschule@stuttgart.de
+13,Grund- und Werkrealschule Ostheim,Baden-Württemberg,Öffentlich,
+14,Pragschule Grundschule,Baden-Württemberg,Öffentlich,poststelle.pragschule@stuttgart.de
+15,Raitelsbergschule Grund- und Hauptschule,Baden-Württemberg,Öffentlich,raitelsbergschule@stuttgart.de
+16,Römerschule Grundschule,Baden-Württemberg,Öffentlich,roemerschule@Stuttgart.de 
+17,Rosensteinschule Grund- und Werkrealschule,Baden-Württemberg,Öffentlich,ingrid.macher@stuttgart.de
+18,Schwabschule Grundschule,Baden-Württemberg,Öffentlich,schwabschule@stuttgart.de
+19,Friedensschule Werkrealschule,Baden-Württemberg,Öffentlich,
+20,Fuchsrainschule Grundschule,Baden-Württemberg,Öffentlich,fuchsrainschule@stuttgart.de
+21,Kirchhaldenschule Grundschule Botnang,Baden-Württemberg,Öffentlich,kirchhaldenschule@stuttgart.de
+22,Franz-Schubert-Schule Grundschule Botnang,Baden-Württemberg,Öffentlich,Franz-Schubert-Schule@stuttgart.de
+23,Bismarckschule Grund- und Werkrealschule Feuerbach,Baden-Württemberg,Öffentlich,
+24,Bachschule Grundschule Feuerbach,Baden-Württemberg,Öffentlich,bachschule@stuttgart.de
+25,Hohewartschule Grundschule,Baden-Württemberg,Öffentlich,hohewartschule@stuttgart.de
+26,Reisachschule Grund- und Hauptschule Weilimdorf,Baden-Württemberg,Öffentlich,
+27,Wolfbuschschule Grund- und Werkrealschule Weilimdorf,Baden-Württemberg,Öffentlich,poststelle@s-wolfbusch.schule.bwl.de
+28,Engelbergschule Grundschule Bergheim,Baden-Württemberg,Öffentlich,poststelle.engelbergschule@stuttgart.de
+29,Rappachschule Grund- und Hauptschule mit Werkrealschule Giebel,Baden-Württemberg,Öffentlich,lange@rappachschule.de
+30,Herbert-Hoover-Schule Grund- und Werkrealschule Freiberg,Baden-Württemberg,Öffentlich,herbert-hoover-schule@stuttgart.de
+31,Grund- und Hauptschule Stammheim,Baden-Württemberg,Öffentlich,poststelle.gwrs.stammheim@stuttgart.de 
+32,Grundschule Zazenhausen,Baden-Württemberg,Öffentlich,gs.zazenhausen@stuttgart.de
+33,Hohensteinschule Grund- und Werkrealschule Zuffenhausen,Baden-Württemberg,Öffentlich,
+34,Hohensteinschule Grund- und Werkrealschule Zuffenhausen Außenstelle Grundschule Marconistr.,Baden-Württemberg,Öffentlich,Hohensteinschule@Stuttgart.de
+35,Rosenschule Grundschule Zuffenhausen,Baden-Württemberg,Öffentlich, rosenschule@stuttgart.de
+36,Neuwirtshausschule Grundschule,Baden-Württemberg,Öffentlich,neuwirtshausschule@stuttgart.de
+37,Silcherschule Grundschule Rot,Baden-Württemberg,Öffentlich,silcherschule@stuttgart.de
+38,Uhland-Schule Grund- und Werkrealschule Rot,Baden-Württemberg,Öffentlich,uhlandschule@stuttgart.de
+39,Altenburgschule,Baden-Württemberg,Öffentlich,altenburgschule@stuttgart.de

--- a/get.py
+++ b/get.py
@@ -1,3 +1,4 @@
+import datetime
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import NoSuchElementException
@@ -6,24 +7,59 @@ options = webdriver.ChromeOptions()
 # chromedriver はバックグラウンドで起動
 options.add_argument('--headless')
 driver = webdriver.Chrome('./chromedriver.exe', options=options)  # Optional argument, if not specified will search path.
-file = open('list.csv', 'w')
+# ファイル名設定
+now = datetime.datetime.now()
+file = open("list" + str(now) + ".csv", "w")
+# csv のヘッダ行を入力
+file.write("No,Name,Bundesland,Schultyp,E-Mail\n")
 
-for i in range(9999):
-	page_no = str(i + 1).zfill(4)
+# 一応確認したが、40000 までは学校のデータが存在した。
+# 50000回のループとし、記入すべきデータが見つからない場合ストップすることに。
+for i in range(50000):
+	page_no = str(i + 1).zfill(5)
 	url = "http://www.schulliste.eu/schule/" + page_no + "-freie-montessori-schule-mkk/"
 	driver.get(url)
+
+	# No
+	no = i + 1
+	
+	# Name
 	try:
 		# 学校名は p 要素かつ class =  map_title red
 		name = driver.find_element(By.XPATH, "//p[@class='map_title red']").text
 	except NoSuchElementException:
-		# 学校名が見つからなかったら unknown と記録
-		name = "unknown"
+		# 学校名が見つからなかったら空
+		name = ""
+	
+	# Bundesland
+	try:
+		# 州名の xpath は a 要素かつ href に bundesland= を含む
+		state = driver.find_element(By.XPATH, "//a[contains(@href, 'bundesland=')]").text
+	except NoSuchElementException:
+		# 州名が見つからなかったら空
+		state = ""
+	
+	# Schultyp
+	try:
+		# 区分の xpath は a 要素かつ href に ?t= を含む
+		classification = driver.find_element(By.XPATH, "//a[contains(@href, '?t=')]").text
+	except NoSuchElementException:
+		# 区分が見つからなかったら空
+		classification = ""
+	
+	# E-mail
 	try:
 		# メールアドレスは a 要素かつ title に @ が含まれるものの title 属性
 		email = driver.find_element(By.XPATH, "//a[contains(@title, '@')]").get_attribute("title")
 	except NoSuchElementException:
-		# メールアドレスが見つからなかったら unknown と記録
-		email = "unknown"
-	file.write(name + "," + email + "\n")
+		# メールアドレスが見つからなかったら空
+		email = ""
+	
+	# 記入すべき情報が何も取れなかった場合ループを抜ける
+	if not name and not state and not classification and not email:
+		break
+	
+	file.write(str(no) + "," + name + "," + state + "," + classification + "," + email + "\n")
 
 driver.quit()
+file.close()


### PR DESCRIPTION
## 内容
- 州名・公立私立の区分を出力に追加
- 出力サンプルを追加

## エビデンス
<img width="1068" alt="image" src="https://user-images.githubusercontent.com/53090180/214091020-0e143657-9ecd-4def-8724-dad6ffa03fce.png">

## 関連
#1 