### PR TITLE
google 検索時の正規表現を修正

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,17 +5,19 @@ from selenium import webdriver
 from enums.where import Where
 from scrapers.site_scraper import SiteScraper
 
-options = webdriver.ChromeOptions()
 # chromedriver はバックグラウンドで起動
+options = webdriver.ChromeOptions()
 options.add_argument('--headless')
 driver = webdriver.Chrome('./chromedriver.exe', options=options)  # Optional argument, if not specified will search path.
-site_scraper = SiteScraper()
+
 # ファイル名設定
 now = datetime.datetime.now()
 file = open("./exports/list" + str(now) + ".csv", "w")
+
 # csv のヘッダ行を入力
 file.write("No,Name,Bundesland,Schultyp,E-Mail,URL,URL(Google)\n")
 
+site_scraper = SiteScraper()
 # 一応確認したが、40000 までは学校のデータが存在した。
 # 50000回のループとし、記入すべきデータが見つからない場合に備えて URL を出力に追加。
 for i in range(50000):
@@ -25,6 +27,7 @@ for i in range(50000):
 
 	# No
 	no = i + 1
+
 	# Name
 	name_xpath = "//p[@class='map_title red']"
 	name = site_scraper.get_data_by_xpath(driver, name_xpath, Where.TEXT, None)	

--- a/scrapers/site_scraper.py
+++ b/scrapers/site_scraper.py
@@ -46,7 +46,7 @@ class SiteScraper:
             # 検索結果が1件もない場合
             return ""
         # hogehoge@test.com. のように末尾に dot がつく場合がそこそこあるので末尾は必ず英数字とする正規表現
-        pattern = re.compile(r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+[a-zA-Z0-9]");
+        pattern = re.compile(r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+[a-zA-Z0-9])");
         result = re.search(pattern, element)
         if result is None:
             # 検索結果の1件目にメールアドレスの記載がない場合


### PR DESCRIPTION
## 内容
google 検索時の正規表現を修正

## 詳細
括弧が抜けていたのが原因でうまく取得できていなかった

## エビデンス
<img width="721" alt="スクリーンショット 2023-01-26 23 12 30" src="https://user-images.githubusercontent.com/53090180/214859276-52a889e1-0fb0-44ce-8336-60ba9cb2d93f.png">
ごっそりと抜けていたブロックで取得できるようになった。