### PR TITLE
Selenium を削除し requests に置き換え / 実行時の出力に進捗度を表示するよう変更 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ $ python3 get-pip.py
 $ pip3 install requests
 $ pip3 install lxml
 $ pip3 install tqdm
+$ pip3 install numpy
 ```
 
 # 使い方

--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ $ curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 $ python3 get-pip.py
 ```
 
-- celenium をインストール
+- ライブラリ をインストール
 
 ```
-$ pip3 install selenium
+$ pip3 install requests
+$ pip3 install lxml
+$ pip3 install tqdm
 ```
 
 # 使い方
@@ -28,16 +30,10 @@ $ pip3 install selenium
 $ python3 main.py
 ```
 
-下記のような出力が出るが気にしなくて OK
-
-```
-/usr/xxx/xxx/scrapingByPython/get.py:10: DeprecationWarning: executable_path has been deprecated, please pass in a Service object
-  driver = webdriver.Chrome('./chromedriver.exe', options=options)  # Optional argument, if not specified will search path.
-```
-
 出力結果は `exports` 下に保存される  
 途中で止めたい時は `Ctrl + C`
 
-# 懸念
+# 注意
 
-chromedriver 古くなると動かないのでダウンロードしてくる必要あり
+google_search_url が入っている場合、「google 検索結果全体から最初にマッチしたメールアドレス」を入れているだけなので、
+メールアドレスが正しいかどうか疑った方が良い。特にドメインがおかしい場合など。

--- a/main.py
+++ b/main.py
@@ -1,14 +1,11 @@
 import datetime
+import re
 
-from selenium import webdriver
+import requests
+import lxml.html
 
 from enums.where import Where
 from scrapers.site_scraper import SiteScraper
-
-# chromedriver はバックグラウンドで起動
-options = webdriver.ChromeOptions()
-options.add_argument('--headless')
-driver = webdriver.Chrome('./chromedriver.exe', options=options)  # Optional argument, if not specified will search path.
 
 # ファイル名設定
 now = datetime.datetime.now()
@@ -17,6 +14,7 @@ file = open("./exports/list" + str(now) + ".csv", "w")
 # csv のヘッダ行を入力
 file.write("No,Name,Bundesland,Schultyp,E-Mail,URL,URL(Google)\n")
 
+# csv に No を振るための変数
 no = 0
 site_scraper = SiteScraper()
 # 一応確認したが、40000 までは学校のデータが存在した。
@@ -24,44 +22,62 @@ site_scraper = SiteScraper()
 for i in range(50000):
 	page_no = str(i + 1).zfill(5)
 	url = "http://www.schulliste.eu/schule/" + page_no + "-freie-montessori-schule-mkk/"
-	driver.get(url)
+	
+	# url にリクエストしてレスポンスを取得
+	response = requests.get(url)
+	
+	# ステータスが200番台でない場合次のループへ
+	if response.status_code is not requests.codes.ok:
+		print(f"このページへのアクセスに失敗しました。status_code={response.status_code}")
+		continue
+
+	# レスポンスを xpath で検索可能な html 型に変換する
+	html = lxml.html.fromstring(response.content)
 
 	# 小学校のデータではない場合、次のループへ
-	if site_scraper.is_elemental_school(driver) is False:
+	if site_scraper.is_elemental_school(html) is False:
 		continue
-	
-	# No
-	no += 1
 
 	# Name
 	name_xpath = "//p[@class='map_title red']"
-	name = site_scraper.get_data_by_xpath(driver, name_xpath, Where.TEXT, None)	
+	name = site_scraper.get_data_by_xpath(html, name_xpath, Where.TEXT)	
 	if name == "":
 		# 学校名がそもそも取れない場合、処理を続けても意味がないので次のループへ
 		continue
 
 	# Bundesland
 	state_xpath = "//a[contains(@href, 'bundesland=')]"
-	state = site_scraper.get_data_by_xpath(driver, state_xpath, Where.TEXT, None)
+	state = site_scraper.get_data_by_xpath(html, state_xpath, Where.TEXT)
 
 	# Schultyp
 	classification_xpath = "//a[contains(@href, '?t=')]"
-	classification = site_scraper.get_data_by_xpath(driver, classification_xpath, Where.TEXT, None)
+	classification = site_scraper.get_data_by_xpath(html, classification_xpath, Where.TEXT)
 
 	# E-mail
-	email_xpath = "//a[contains(@title, '@')]"
-	email = site_scraper.get_data_by_xpath(driver, email_xpath, Where.ATTRIBUTE, "title")
+	email_xpath = "//a[contains(@title, '@')]/@title"
+	email = site_scraper.get_data_by_xpath(html, email_xpath, Where.ATTRIBUTE)
 	if email == "":
 		# 例のサイトにデータがない場合、google で検索する
 		formatted_name = name.replace(" ", "+")
 		google_search_url = f'https://www.google.com/search?q={formatted_name}+%22e-mail%22'
-		email = site_scraper.google_search(driver, google_search_url)
+		google_search_response = requests.get(url)
+		# メールアドレスにマッチする正規表現
+		pattern = re.compile(r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+[a-zA-Z0-9])");
+		# メールアドレスは、google 検索結果全体から探す
+		result = re.search(pattern, google_search_response.content.decode())
+		if result is None:
+			# 検索結果にメールアドレスの記載がない場合
+			email = ""
+		email = result.group()
 	else:
 		# google 検索しない場合は空
+		# このカラムにデータがある場合、メールアドレスが正確か疑った方が良い
 		google_search_url = ""
+	
+	# このデータに採番される No
+	no += 1
 
 	# ファイル書き込み
 	file.write(f'{str(no)},"{name}","{state}","{classification}","{email}","{url}","{google_search_url}"' + "\n")
 
-driver.quit()
 file.close()

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 import datetime
 import re
+import tqdｍ
+import numpy as np
 
 import requests
 import lxml.html
@@ -19,7 +21,11 @@ no = 0
 site_scraper = SiteScraper()
 # 一応確認したが、40000 までは学校のデータが存在した。
 # 50000回のループとし、記入すべきデータが見つからない場合に備えて URL を出力に追加。
-for i in range(50000):
+for i in tqdm.tqdm(range(50000)):
+	# ループの進捗状況を出力
+	np.pi*np.pi
+
+	# 今回アクセスする url を作る
 	page_no = str(i + 1).zfill(5)
 	url = "http://www.schulliste.eu/schule/" + page_no + "-freie-montessori-schule-mkk/"
 	

--- a/scrapers/site_scraper.py
+++ b/scrapers/site_scraper.py
@@ -1,72 +1,44 @@
-import re
-
-from selenium.webdriver.common.by import By
-from selenium.common.exceptions import NoSuchElementException
 from enums.where import Where
 
 class SiteScraper:
 
     @staticmethod
-    def is_elemental_school(driver):
+    def is_elemental_school(html):
         """渡されたページ情報から、そのページが小学校のものかどうかを判定する
         
         Keyword arguments:
-        driver -- celenium の webdriver
+        html -- requests で取得した html
         """
         try:
-            elements = driver.find_elements(By.XPATH, "//a[contains(@title, 'Zu Schulen im Fachbereich übergehen')]")
+            elements = html.xpath("//a[contains(@title, 'Zu Schulen im Fachbereich übergehen')]")
             for element in elements:
                 # 取得した要素に Grund が含まれる文字列があれば true
                 if "Grund" in element.text:
                     return True
-        except NoSuchElementException:
+        except IndexError:
             # そもそもカテゴリが見つからない場合
             return False
         return False
         
 
     @staticmethod
-    def get_data_by_xpath(driver, xpath, where, attribute_name):
+    def get_data_by_xpath(html, xpath, where):
         """データを xpath を用いて取得し、返却する
         
         Keyword arguments:
-        driver -- celenium の webdriver
+        html -- requests で取得した html
         xpath -- データがあると思われる xpath
         where -- xpath で取得したデータのどの部分が欲しいか
                 ex: text -> Where.TEXT
-        attribute_name -- Where.ATTRIBUTE が指定されている場合、どの attribute から取得するか
-                ex: href の中身が欲しい -> href
         """
         try:
-            element = driver.find_element(By.XPATH, xpath)
-        except NoSuchElementException:
-            # データが見つからなかったら空
+            element = html.xpath(xpath)[0]
+        except IndexError:
             return ""
         if where is Where.TEXT:
             return element.text
         if where is Where.ATTRIBUTE:
-            return element.get_attribute(attribute_name)
+            # attribute から取得するとき、element は配列ではない
+            return element
         # where の指定が想定外の場合も空文字を返却
         return ""
-
-    @staticmethod
-    def google_search(driver, url):
-        """学校名 + e-mail で google 検索し、検索結果からメールアドレスを探して返却する
-
-        driver -- celenium の webdriver
-        url -- 検索用 URL
-        """
-        driver.get(url)
-        try:
-            # 取得範囲は検索結果の全体
-            element = driver.find_element(By.XPATH, "//div[@class='GyAeWb']").text
-        except NoSuchElementException:
-            # 検索結果が1件もない場合
-            return ""
-        # hogehoge@test.com. のように末尾に dot がつく場合がそこそこあるので末尾は必ず英数字とする正規表現
-        pattern = re.compile(r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+[a-zA-Z0-9])");
-        result = re.search(pattern, element)
-        if result is None:
-            # 検索結果の1件目にメールアドレスの記載がない場合
-            return ""
-        return result.group()


### PR DESCRIPTION
## 内容
- Selenium を削除し requests に置き換え
- 実行時の出力に進捗度を表示するよう変更 

## 詳細
結果的にブラウザ操作を伴わないロジックとなったため、selenium を使う必要はなく、むしろ requests の方が高速なため置き換えを行った。
また、実行時の出力に進捗度を表示するように変更した。
これによって、パフォーマンスが数字でわかるようになった。

## エビデンス
- csv が出力できていること
<img width="721" alt="image" src="https://user-images.githubusercontent.com/53090180/215113856-ee44be80-92b8-414d-b65d-23fbdfce99a2.png">

- 進捗度が出力されていること
```
$ python3 main.py   
  0%|                                                                                                | 50/50000 [01:27<21:16:31,  1.53s/it]
```

## 関連
#17 これは対応不要に
