### PR TITLE
google 検索先 url が誤っているバグを修正 / get 時に user agent を指定するよう変更

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,6 +18,10 @@ file.write("No,Name,Bundesland,Schultyp,E-Mail,URL,URL(Google)\n")
 
 # csv に No を振るための変数
 no = 0
+user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
+header = {
+    'User-Agent': user_agent
+}
 site_scraper = SiteScraper()
 # 一応確認したが、40000 までは学校のデータが存在した。
 # 50000回のループとし、記入すべきデータが見つからない場合に備えて URL を出力に追加。
@@ -30,7 +34,7 @@ for i in tqdm.tqdm(range(50000)):
 	url = "http://www.schulliste.eu/schule/" + page_no + "-freie-montessori-schule-mkk/"
 	
 	# url にリクエストしてレスポンスを取得
-	response = requests.get(url)
+	response = requests.get(url, headers=header)
 	
 	# ステータスが200番台でない場合次のループへ
 	if response.status_code is not requests.codes.ok:
@@ -65,16 +69,17 @@ for i in tqdm.tqdm(range(50000)):
 	if email == "":
 		# 例のサイトにデータがない場合、google で検索する
 		formatted_name = name.replace(" ", "+")
-		google_search_url = f'https://www.google.com/search?q={formatted_name}+%22e-mail%22'
-		google_search_response = requests.get(url)
+		google_search_url = 'https://www.google.com/search'
+		google_search_response = requests.get(google_search_url, headers=header, params={'q': f'{formatted_name} e-mail'})
 		# メールアドレスにマッチする正規表現
-		pattern = re.compile(r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+[a-zA-Z0-9])");
+		pattern = re.compile(r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+[a-zA-Z0-9]");
 		# メールアドレスは、google 検索結果全体から探す
 		result = re.search(pattern, google_search_response.content.decode())
 		if result is None:
 			# 検索結果にメールアドレスの記載がない場合
 			email = ""
-		email = result.group()
+		else:
+			email = result.group()
 	else:
 		# google 検索しない場合は空
 		# このカラムにデータがある場合、メールアドレスが正確か疑った方が良い


### PR DESCRIPTION
## 内容
- google 検索先 url が誤っているバグを修正
- get 時に user agent を指定するよう変更
- そのほか細かい修正

## 詳細
- google 検索先 url が誤っているバグを修正
  - 検索先 url が例のサイトになってしまっていたので修正・・・しっかり自己レビューすること
- get 時に user agent を指定するよう変更
  - 検索結果がブラウザで見た時と異なる場合があるため
- そのほか細かい修正
  - メールアドレスが取得できなかった場合のロジック修正
  - リクエスト時、パラメータは引数に辞書で渡すよう修正