### PR TITLE
email に空白が含まれる場合削除するよう修正

### DIFF
--- a/main.py
+++ b/main.py
@@ -89,6 +89,6 @@ for i in tqdm.tqdm(range(50000)):
 	no += 1
 
 	# ファイル書き込み
-	file.write(f'{str(no)},"{name}","{state}","{classification}","{email}","{url}","{google_search_url}"' + "\n")
+	file.write(f'{str(no)},"{name}","{state}","{classification}","{email.replace(" ", "")}","{url}","{google_search_url}"' + "\n")
 
 file.close()


### PR DESCRIPTION
## 内容
email に空白が含まれる場合削除するよう修正

## 詳細
例のサイトから email を取得する場合、おそらく登録時の typo でメールアドレスに空白が含まれる場合があった。
なので、email に関してはこれを削除することとした。
（この値をコピペして利用するため、余計な文字は消したい）
学校名や地名などは普通にスペースが入るべきものもあるためそのままとする。

## エビデンス
空白が削除されていること
- 対応前
```
6,"Heusteigschule Grund- und Werkrealschule","Baden-Württemberg","Öffentlich"," heusteigschule@stuttgart.de","http://www.schulliste.eu/schule/00006-freie-montessori-schule-mkk/",""
7,"Grundschule im Sonnigen Winkel","Baden-Württemberg","Öffentlich","schule.im.sonnigen.winkel@stuttgart. de","http://www.schulliste.eu/schule/00007-freie-montessori-schule-mkk/",""
```

- 対応後(採番が変わっているが、同じ学校のデータ）
```
1,"Heusteigschule Grund- und Werkrealschule","Baden-Württemberg","Öffentlich","heusteigschule@stuttgart.de","http://www.schulliste.eu/schule/00006-freie-montessori-schule-mkk/",""
2,"Grundschule im Sonnigen Winkel","Baden-Württemberg","Öffentlich","schule.im.sonnigen.winkel@stuttgart.de","http://www.schulliste.eu/schule/00007-freie-montessori-schule-mkk/",""
```