### PR TITLE
e-mail が google 検索で取得できなかった場合のバグ修正

### DIFF
--- a/main.py
+++ b/main.py
@@ -68,11 +68,14 @@ for i in tqdm.tqdm(range(50000)):
 		# "email" ダブルクオートで囲むことで検索精度を上げることができる
 		search_words = [name, "\"e-mail\""];
 		google_search_response = GoogleSearchScraper.scrape(search_words);
-		# google 検索でも見つからなかった場合 email = ""
-		email = GoogleSearchResponseParser.parse(Patterns.EMAIL.value, google_search_response).group() or "";
+		result = GoogleSearchResponseParser.parse(Patterns.EMAIL.value, google_search_response);
+		if result is not None:
+			# メールアドレスが見つかった場合
+			email = result.group();
+		# URL(Google)
 		google_search_url_for_export = google_search_response.url;
 	else:
-		# google 検索しない場合は空
+		# URL(Google) google 検索しない場合は空
 		google_search_url_for_export = ""
 	
 	# このデータに採番される No


### PR DESCRIPTION
## 内容
e-mail が google 検索で取得できなかった場合のバグ修正

## 詳細
e-mail が取得できなかった場合に、動作が停止してしまっていた。
```
$ python3 main.py                          
  0%|▎                                                                                              | 183/50000 [05:04<23:01:07,  1.66s/it]
Traceback (most recent call last):
  File "/Users/katayamajunpei/works/playground/scrapingByPython/main.py", line 72, in <module>
    email = GoogleSearchResponseParser.parse(Patterns.EMAIL.value, google_search_response).group() or "";
AttributeError: 'NoneType' object has no attribute 'group'
```

`or` を使って代入していたのがよくなかったので普通の if 文に変更。

## エビデンス
- google 検索しても取得できないメールアドレスは空で入っていること
<img width="706" alt="image" src="https://user-images.githubusercontent.com/53090180/215513262-66aad1ec-ff7f-4dc3-abd4-3fccc7996994.png">
